### PR TITLE
feat(core, docs): Add `SetStateAction` type of setting history context

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Supports browser history, react-router-dom, next.js, @react-navigation/native, a
 
 ## Example
 
+
+https://github.com/user-attachments/assets/8300d4ed-ab02-436e-a5a6-99c8d732e32f
+
+
 ```tsx
 import { useFunnel } from '@use-funnel/react-router-dom';
 

--- a/README.md
+++ b/README.md
@@ -31,30 +31,72 @@ import { useFunnel } from '@use-funnel/react-router-dom';
 
 export function App() {
   const funnel = useFunnel<{
-    Step1: { message?: string; flag?: boolean };
-    Step2: { message: string; flag?: boolean };
-    Step3: { message: string; flag: boolean };
+    SelectJob: { jobType?: 'STUDENT' | 'EMPLOYEE' };
+    SelectSchool: { jobType: 'STUDENT'; school?: string };
+    SelectEmployee: { jobType: 'EMPLOYEE'; company?: string };
+    EnterJoinDate: { jobType: 'STUDENT'; school: string } | { jobType: 'EMPLOYEE'; company: string };
+    Confirm: ({ jobType: 'STUDENT'; school: string } | { jobType: 'EMPLOYEE'; company: string }) & { joinDate: string };
   }>({
     id: 'hello-world',
     initial: {
-      step: 'Step1',
+      step: 'SelectJob',
       context: {},
     },
   });
   return (
     <funnel.Render
-      Step1={({ history }) => <Step1 onNext={(message) => history.push('Step2', { message })} />}
-      Step2={({ context, history }) => (
-        <Step2 message={context.message} onNext={(flag) => history.push('Step3', { flag })} />
+      SelectJob={funnel.Render.with({
+        events: {
+          selectSchool: (_, { history }) => history.push('SelectSchool', { jobType: 'STUDENT' }),
+          selectEmployee: (_, { history }) => history.push('SelectEmployee', { jobType: 'EMPLOYEE' }),
+        },
+        render({ dispatch }) {
+          return (
+            <SelectJob
+              onSelectSchool={() => dispatch('selectSchool')}
+              onSelectEmployee={() => dispatch('selectEmployee')}
+            />
+          );
+        },
+      })}
+      SelectSchool={({ history }) => <SelectSchool onNext={(school) => history.push('EnterJoinDate', { school })} />}
+      SelectEmployee={({ history }) => (
+        <SelectEmployee
+          onNext={(company) =>
+            history.push('EnterJoinDate', (prev) => ({
+              ...prev,
+              company,
+            }))
+          }
+        />
       )}
-      Step3={({ context }) => <Step3 message={context.message} flag={context.flag} />}
+      EnterJoinDate={funnel.Render.overlay({
+        render({ history, close }) {
+          return (
+            <EnterJoinDateBottomSheet
+              onNext={(joinDate) => history.push('Confirm', { joinDate })}
+              onClose={() => close()}
+            />
+          );
+        },
+      })}
+      Confirm={({ context }) =>
+        context.jobType === 'STUDENT' ? (
+          <ConfirmStudent school={context.school} joinDate={context.joinDate} />
+        ) : (
+          <ConfirmEmployee company={context.company} joinDate={context.joinDate} />
+        )
+      }
     />
   );
 }
 
-declare function Step1(props: { onNext: (message: string) => void }): React.ReactNode;
-declare function Step2(props: { message: string; onNext: (flag: boolean) => void }): React.ReactNode;
-declare function Step3(props: { message: string; flag: boolean }): React.ReactNode;
+declare function SelectJob(props: { onSelectSchool(): void; onSelectEmployee(): void }): JSX.Element;
+declare function SelectSchool(props: { onNext(school: string): void }): JSX.Element;
+declare function SelectEmployee(props: { onNext(company: string): void }): JSX.Element;
+declare function EnterJoinDateBottomSheet(props: { onNext(joinDate: string): void; onClose(): void }): JSX.Element;
+declare function ConfirmStudent(props: { school: string; joinDate: string }): JSX.Element;
+declare function ConfirmEmployee(props: { company: string; joinDate: string }): JSX.Element;
 ```
 
 ## Visit [use-funnel.slash.page](https://use-funnel.slash.page) for docs, guides, API and more!

--- a/docs/src/pages/docs/use-funnel.en.mdx
+++ b/docs/src/pages/docs/use-funnel.en.mdx
@@ -80,8 +80,8 @@ An object that manages the transitions of the funnel. It contains several method
 
 ```tsx
 interface FunnelHistory<T> {
-  push: <TStep extends keyof T>(step: TStep, context: T[TStep]) => Promise<void> | void;
-  replace: <TStep extends keyof T>(step: TStep, context: T[TStep]) => Promise<void> | void;
+  push: <TStep extends keyof T>(step: TStep, context: T[TStep] | SetStateAction<T[TStep]>) => Promise<void> | void;
+  replace: <TStep extends keyof T>(step: TStep, context: T[TStep] | SetStateAction<T[TStep]>) => Promise<void> | void;
   go: (index: number) => void | Promise<void>;
   back: () => void | Promise<void>;
 }
@@ -89,10 +89,10 @@ interface FunnelHistory<T> {
 
 - `push` (`function`): Adds a new state and moves to the next funnel step.
   - `step` (`string`): The name of the next step.
-  - `context` (`object`): An object representing the state of the next step.
+  - `context` (`object`): An object representing the state of the next step. You can also pass a function that uses the current step state to create the next step state.
 - `replace` (`function`): Replaces the current state with a new one and transitions to the next step.
   - `step` (`string`): The name of the next step.
-  - `context` (`object`): An object representing the state of the next step.
+  - `context` (`object`): An object representing the state of the next step. You can also pass a function that uses the current step state to create the next step state.
 - `go` (`function`): Moves to the step at the specified index in the `historySteps` array.
   - `index` (`number`): The index of the step to move to.
 - `back` (`function`): Moves to the previous step.

--- a/docs/src/pages/docs/use-funnel.en.mdx
+++ b/docs/src/pages/docs/use-funnel.en.mdx
@@ -79,9 +79,9 @@ type UseFunnelResults<T> = {
 An object that manages the transitions of the funnel. It contains several methods for handling the transition of the funnel steps.
 
 ```tsx
-interface FunnelHistory<T> {
-  push: <TStep extends keyof T>(step: TStep, context: T[TStep] | SetStateAction<T[TStep]>) => Promise<void> | void;
-  replace: <TStep extends keyof T>(step: TStep, context: T[TStep] | SetStateAction<T[TStep]>) => Promise<void> | void;
+interface FunnelHistory<TContextMap, TCurrentStep extends keyof TContextMap> {
+  push: <TTargetStep extends keyof TContextMap>(step: TTargetStep, context: TContextMap[TTargetStep] | ((prev: TContextMap<TCurrentStep>) => T[TTargetStep])) => Promise<void> | void;
+  replace: <TTargetStep extends keyof TContextMap>(step: TTargetStep, context: TContextMap[TTargetStep] | ((prev: TContextMap<TCurrentStep>) => T[TTargetStep])) => Promise<void> | void;
   go: (index: number) => void | Promise<void>;
   back: () => void | Promise<void>;
 }
@@ -89,10 +89,10 @@ interface FunnelHistory<T> {
 
 - `push` (`function`): Adds a new state and moves to the next funnel step.
   - `step` (`string`): The name of the next step.
-  - `context` (`object`): An object representing the state of the next step. You can also pass a function that uses the current step state to create the next step state.
+  - `context` (`object` | `function`): An object representing the state of the next step. You can also pass a function that uses the current step state to create the next step state.
 - `replace` (`function`): Replaces the current state with a new one and transitions to the next step.
   - `step` (`string`): The name of the next step.
-  - `context` (`object`): An object representing the state of the next step. You can also pass a function that uses the current step state to create the next step state.
+  - `context` (`object` | `function`): An object representing the state of the next step. You can also pass a function that uses the current step state to create the next step state.
 - `go` (`function`): Moves to the step at the specified index in the `historySteps` array.
   - `index` (`number`): The index of the step to move to.
 - `back` (`function`): Moves to the previous step.

--- a/docs/src/pages/docs/use-funnel.ko.mdx
+++ b/docs/src/pages/docs/use-funnel.ko.mdx
@@ -78,8 +78,8 @@ type UseFunnelResults<T> = {
 
 ```tsx
 interface FunnelHistory<T> {
-  push: <TStep extends keyof T>(step: TStep, context: T[TStep]) => Promise<void> | void;
-  replace: <TStep extends keyof T>(step: TStep, context: T[TStep]) => Promise<void> | void;
+  push: <TStep extends keyof T>(step: TStep, context: T[TStep] | SetStateAction<T[TStep]>) => Promise<void> | void;
+  replace: <TStep extends keyof T>(step: TStep, context: T[TStep] | SetStateAction<T[TStep]>) => Promise<void> | void;
   go: (index: number) => void | Promise<void>;
   back: () => void | Promise<void>;
 }
@@ -87,10 +87,10 @@ interface FunnelHistory<T> {
 
 - `push` (`function`): 새로운 단계로 이동해요. 이전 단계의 히스토리를 남겨요.
   - `step` (`string`): 이동할 단계의 이름이에요.
-  - `context` (`object`): 이동할 단계의 상태를 나타내는 객체에요.
+  - `context` (`object`): 이동할 단계의 상태를 나타내는 객체에요. 혹은 현재 단계 상태를 이용해서 다음 단계 상태를 만드는 함수를 넣을 수 있어요.
 - `replace` (`function`): 새로운 단계로 이동해요. 이전 단계의 히스토리를 남기지 않아요.
   - `step` (`string`): 이동할 단계의 이름입니다.
-  - `context` (`object`): 이동할 단계의 상태를 나타내는 객체입니다.
+  - `context` (`object`): 이동할 단계의 상태를 나타내는 객체입니다. 혹은 현재 단계 상태를 이용해서 다음 단계 상태를 만드는 함수를 넣을 수 있어요.
 - `go` (`function`): 현재 인덱스 기준으로 지정된 단계로 이동해요.
   - `index` (`number`): 이동하려는 단계의 인덱스에요. 현재 단계로부터의 **상대적인 위치**를 나타내요.
 - `back` (`function`): 이전 단계로 이동해요.

--- a/docs/src/pages/docs/use-funnel.ko.mdx
+++ b/docs/src/pages/docs/use-funnel.ko.mdx
@@ -77,9 +77,9 @@ type UseFunnelResults<T> = {
 퍼널의 이동을 관리하는 객체에요. 퍼널의 단계 전환을 처리하는 여러 메서드를 포함하고 있어요.
 
 ```tsx
-interface FunnelHistory<T> {
-  push: <TStep extends keyof T>(step: TStep, context: T[TStep] | SetStateAction<T[TStep]>) => Promise<void> | void;
-  replace: <TStep extends keyof T>(step: TStep, context: T[TStep] | SetStateAction<T[TStep]>) => Promise<void> | void;
+interface FunnelHistory<TContextMap, TCurrentStep extends keyof TContextMap> {
+  push: <TTargetStep extends keyof TContextMap>(step: TTargetStep, context: TContextMap[TTargetStep] | ((prev: TContextMap<TCurrentStep>) => T[TTargetStep])) => Promise<void> | void;
+  replace: <TTargetStep extends keyof TContextMap>(step: TTargetStep, context: TContextMap[TTargetStep] | ((prev: TContextMap<TCurrentStep>) => T[TTargetStep])) => Promise<void> | void;
   go: (index: number) => void | Promise<void>;
   back: () => void | Promise<void>;
 }
@@ -87,10 +87,10 @@ interface FunnelHistory<T> {
 
 - `push` (`function`): 새로운 단계로 이동해요. 이전 단계의 히스토리를 남겨요.
   - `step` (`string`): 이동할 단계의 이름이에요.
-  - `context` (`object`): 이동할 단계의 상태를 나타내는 객체에요. 혹은 현재 단계 상태를 이용해서 다음 단계 상태를 만드는 함수를 넣을 수 있어요.
+  - `context` (`object` | `function`): 이동할 단계의 상태를 나타내는 객체에요. 혹은 현재 단계 상태를 이용해서 다음 단계 상태를 만드는 함수를 넣을 수 있어요.
 - `replace` (`function`): 새로운 단계로 이동해요. 이전 단계의 히스토리를 남기지 않아요.
   - `step` (`string`): 이동할 단계의 이름입니다.
-  - `context` (`object`): 이동할 단계의 상태를 나타내는 객체입니다. 혹은 현재 단계 상태를 이용해서 다음 단계 상태를 만드는 함수를 넣을 수 있어요.
+  - `context` (`object` | `function`): 이동할 단계의 상태를 나타내는 객체입니다. 혹은 현재 단계 상태를 이용해서 다음 단계 상태를 만드는 함수를 넣을 수 있어요.
 - `go` (`function`): 현재 인덱스 기준으로 지정된 단계로 이동해요.
   - `index` (`number`): 이동하려는 단계의 인덱스에요. 현재 단계로부터의 **상대적인 위치**를 나타내요.
 - `back` (`function`): 이전 단계로 이동해요.

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -23,10 +23,16 @@ type TransitionFnArguments<TName extends PropertyKey, TContext> =
 type TransitionFn<TState extends AnyFunnelState, TNextState extends AnyFunnelState> = <
   TName extends TNextState['step'],
 >(
-  ...args: TransitionFnArguments<
-    TName,
-    CompareMergeContext<TState['context'], GetFunnelStateByName<TNextState, TName>['context']>
-  >
+  ...args:
+    | TransitionFnArguments<
+        TName,
+        CompareMergeContext<TState['context'], GetFunnelStateByName<TNextState, TName>['context']>
+      >
+    | [
+        target: TName,
+        callback: (prev: TState['context']) => GetFunnelStateByName<TNextState, TName>['context'],
+        option?: FunnelRouterTransitionOption,
+      ]
 ) => Promise<GetFunnelStateByName<TNextState, TName>>;
 
 export type FunnelStateByContextMap<TStepContextMap extends AnyStepContextMap> = {

--- a/packages/core/src/useFunnel.tsx
+++ b/packages/core/src/useFunnel.tsx
@@ -71,11 +71,14 @@ export function createUseFunnel(useFunnelRouter: FunnelRouter): UseFunnel {
     );
 
     const history: FunnelHistory<TStepContextMap, keyof TStepContextMap & string> = useMemo(() => {
-      const transition = (step: keyof TStepContextMap, assignContext?: object) => {
-        const newContext = {
-          ...currentStateRef.current.context,
-          ...assignContext,
-        };
+      const transition = (step: keyof TStepContextMap, assignContext?: object | ((prev: object) => object)) => {
+        const newContext =
+          typeof assignContext === 'function'
+            ? assignContext(currentStateRef.current.context)
+            : {
+                ...currentStateRef.current.context,
+                ...assignContext,
+              };
         const context = parseStepContext(step, newContext);
         return context == null
           ? optionsRef.current.initial
@@ -100,7 +103,7 @@ export function createUseFunnel(useFunnelRouter: FunnelRouter): UseFunnel {
         go: router.go,
         back: () => router.go(-1),
       };
-    }, [router.replace, router.push, router.go, optionsRef]);
+    }, [router.replace, router.push, router.go, optionsRef, parseStepContext]);
 
     const step = useMemo(() => {
       const validContext = parseStepContext(currentState.step, currentState.context);
@@ -115,7 +118,7 @@ export function createUseFunnel(useFunnelRouter: FunnelRouter): UseFunnel {
         index: router.currentIndex,
         historySteps: router.history,
       };
-    }, [currentState, history, router.history, router.currentIndex]);
+    }, [currentState, history, router.history, router.currentIndex, parseStepContext]);
 
     const currentStepStoreRef = useStateSubscriberStore(step);
 

--- a/packages/core/test/useFunnel.test.tsx
+++ b/packages/core/test/useFunnel.test.tsx
@@ -135,8 +135,8 @@ describe('Test useFunnel()', () => {
           <funnel.Render
             A={funnel.Render.with({
               events: {
-                GoB: (payload: { id: string }, { history }) => {
-                  history.push('B', { id: payload.id });
+                GoB: ({ id }: { id: string }, { history }) => {
+                  history.push('B', (prev) => ({ ...prev, id }));
                 },
               },
               render({ dispatch }) {


### PR DESCRIPTION
When transitioning to union type, if the type does not match the current type of staff, you will not be able to deduce the exact type. Also, some people would prefer to save the status of React's SetStateAction, but this was not considered.

Add a SetStateAction type that takes the current context in current step of a callback and specifies the context for the next step.

close #28 