### PR TITLE
fix(docs, core): translated the Korean that needed to be expressed in English

### DIFF
--- a/docs/src/pages/docs/features.en.mdx
+++ b/docs/src/pages/docs/features.en.mdx
@@ -85,8 +85,6 @@ if (funnel.step === "A") {
 }
 ```
 
-{/* 이 코드에서 에러가 발생하는 이유는 빈 객체 `{}`를 사용해서 `B` <Keyword>step</Keyword>으로 전환하려고 시도하기 때문이에요. B <Keyword>step</Keyword>의 타입 정의에 따르면, `b`는 필수로 값이 필요한 프로퍼티에요. 빈 객체는 이러한 타입 정의와 다르기 때문에 에러가 발생합니다.
- */}
 The error occurs because you are trying to transition to the `B` step using an empty object `{}`. According to the type definition of the `B` step, `b` is a required property. Since an empty object does not match this type definition, an error occurs.
 
 To resolve the error, you need to provide the required property `b` value when transitioning to the `B` step. For example, you can modify the code as follows:

--- a/docs/src/pages/docs/transition-event.en.mdx
+++ b/docs/src/pages/docs/transition-event.en.mdx
@@ -20,12 +20,12 @@ const funnel = useFunnel(/* ... */);
       // Email input success event
       EmailInputSuccess: (email: string, { history }) => {
         // Transition to the password input step
-        history.push('비밀번호입력', { email });
+        history.push('PasswordInput', { email });
       },
-      // 이메일 입력 Fail 이벤트
+      // Email input fail event
       EmailInputFail: (error: Error, { history }) => {
         // Transition to the error page
-        history.push('에러페이지', { error: error.message });
+        history.push('ErrorPage', { error: error.message });
       }
     },
     render({ context, dispatch }) {

--- a/packages/core/src/typeUtil.ts
+++ b/packages/core/src/typeUtil.ts
@@ -1,6 +1,6 @@
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 /**
- * TBase에서 TResult로 변환할때, 필수로 필요한 키들을 추출한다.
+ * Extracts the keys that are required when converting from TBase to TResult.
  * @example RequiredCompareKeys<{a: string, b?: string}, {a: string, b: string}> // 'b'
  */
 export type RequiredCompareKeys<TBase, TResult> = {
@@ -18,7 +18,7 @@ export type RequiredCompareKeys<TBase, TResult> = {
 }[keyof TBase | keyof TResult];
 
 /**
- * TBase에서 TResult로 변환할때, 선택적으로 필요한 키들을 추출한다.
+ * Extracts the keys that are optional when converting from TBase to TResult.
  * @example OptionalCompareKeys<{a: string, b?: string}, {a: string, b: string}> // 'a'
  */
 type OptionalCompareKeys<TBase, TResult> = {
@@ -36,8 +36,8 @@ type OptionalCompareKeys<TBase, TResult> = {
 }[keyof TBase | keyof TResult];
 
 /**
- * TBase와 TResult를 비교하여, 필수로 필요한 키들은 TResult의 값을 사용하고,
- * 선택적으로 필요한 키들은 TBase의 값을 사용하여 새로운 객체를 만든다.
+ * Compares TBase with TResult to create a new object that uses TResult's values for required keys,
+ * and TBase's values for optional keys.
  */
 export type CompareMergeContext<TBase, TResult> = Prettify<
   {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -7,7 +7,7 @@ interface Store<T> {
 }
 
 /**
- * 훅 내부에서 컴포넌트를 만들 때 훅의 상태를 해당 컴포넌트에 전달하고 싶을 때 사용하는 훅
+ * A hook used to pass the state of the hook to a component when creating the component inside the hook.
  */
 export function useStateSubscriberStore<T>(state: T) {
   const stateRef = useRef(state);


### PR DESCRIPTION
- Changed the JSDoc comments in the code from Korean to English.
- Translated the parts in the English version of the documentation that still contained Korean into English.

I believe that the use-funnel library is likely aimed at a global audience rather than just Korea. Therefore, I thought it was important to ensure that English is used consistently, which is why I undertook this task. Thank you for creating such a great library!