### PR TITLE
docs: fix missing letter

### DIFF
--- a/docs/src/pages/docs/funnel-render.ko.mdx
+++ b/docs/src/pages/docs/funnel-render.ko.mdx
@@ -3,7 +3,7 @@ import { Keyword, UseFunnelCodeBlock } from '@/components'
 
 # funnel.Render 컴포넌트
 
-`funnel.Render />`는 퍼널의 각 <Keyword>step</Keyword>를 렌더링해요. 
+`<funnel.Render />`는 퍼널의 각 <Keyword>step</Keyword>를 렌더링해요. 
 
 [`useFunnel(){:tsx}`](./use-funnel)의 반환값인 [UseFunnelResults](/docs/use-funnel#usefunnelresults)에 포함되어 있어요.
 


### PR DESCRIPTION
Fixed missing characters in [funnel.Render](https://use-funnel.slash.page/ko/docs/funnel-render) Korean document.

```diff
- `funnel.Render />`는 퍼널의 각 <Keyword>step</Keyword>를 렌더링해요. 
+ `<funnel.Render />`는 퍼널의 각 <Keyword>step</Keyword>를 렌더링해요. 
```