### PR TITLE
chore(docs): createFunnelSteps로 정의하기 부분 하이라이팅 코드 블럭 위치 수정

### DIFF
--- a/docs/src/pages/docs/context-guide.ko.mdx
+++ b/docs/src/pages/docs/context-guide.ko.mdx
@@ -128,7 +128,7 @@ declare function createFunnelSteps<FormState>(): {
 
 
 <UseFunnelCodeBlock>
-```tsx {3-13, 22}
+```tsx {3-13, 18}
 import { createFunnelSteps, useFunnel } from "@use-funnel/next";
 
 type FormState = {


### PR DESCRIPTION
국문과 영문의 컨텐츠가 달라 하이라이팅 되어야할 부분이 잘못 표시된 것 같습니다!
아니면 영문과 동일하게 코드를 수정해도 괜찮을 것 같네요!

```tsx
const funnel = useFunnel({
    id: "create-funnel-steps",
    inital: {
        step: "이메일입력",
        context: {}
    },
    steps
});
```