### PR TITLE
docs: fix the link

### DIFF
--- a/docs/src/pages/docs/install.en.mdx
+++ b/docs/src/pages/docs/install.en.mdx
@@ -4,7 +4,7 @@
 
 - [react-router-dom](https://reactrouter.com/web/guides/quick-start)
 - [next.js page router](https://nextjs.org/docs/pages)
-  - For the [next.js app router](https://nextjs.org/docs/app-building), use [browser history](https://developer.mozilla.org/en-US/docs/Web/API/History).
+  - For the [next.js app router](https://nextjs.org/docs/app/building-your-application), use [browser history](https://developer.mozilla.org/en-US/docs/Web/API/History).
 - [@react-navigation/native](https://reactnavigation.org/docs/getting-started)
 - [browser history](https://developer.mozilla.org/en-US/docs/Web/API/History)
 


### PR DESCRIPTION
I fixed the link in the [docs - Installing](https://use-funnel.slash.page/docs/install) section for the `Next.js App Router`.

<img width="480" alt="image" src="https://github.com/user-attachments/assets/c750efa2-7fd5-4784-b0cd-569b4b6303dc">

