### PR TITLE
fix(docs): type error in SelectSchool within funnel.Render example from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,16 @@ export function App() {
           );
         },
       })}
-      SelectSchool={({ history }) => <SelectSchool onNext={(school) => history.push('EnterJoinDate', { school })} />}
+      SelectSchool={({ history }) => (
+        <SelectSchool 
+          onNext={(school) => 
+            history.push('EnterJoinDate', (prev) => ({ 
+                ...prev, 
+                school 
+            }))
+          } 
+        />
+      )}
       SelectEmployee={({ history }) => (
         <SelectEmployee
           onNext={(company) =>


### PR DESCRIPTION
- #60 

Updated the `SelectSchool` logic to correctly pass the `school parameter` into `history.push` by aligning the usage with the proper type expectations.
Ensured consistency with the SelectEmployee implementation, which did not exhibit the same error.

