### PR TITLE
fix(core): add state initial fallback when history array is empty

### DIFF
--- a/.changeset/modern-moons-arrive.md
+++ b/.changeset/modern-moons-arrive.md
@@ -1,0 +1,9 @@
+---
+'@use-funnel/core': patch
+'@use-funnel/browser': patch
+'@use-funnel/next': patch
+'@use-funnel/react-navigation-native': patch
+'@use-funnel/react-router-dom': patch
+---
+
+fix(core): add state initial fallback when history array is empty

--- a/packages/core/src/useFunnel.tsx
+++ b/packages/core/src/useFunnel.tsx
@@ -57,7 +57,7 @@ export function createUseFunnel<TRouteOption extends RouteOption>(
       id: options.id,
       initialState: options.initial,
     });
-    const currentState = router.history[router.currentIndex] as FunnelStateByContextMap<TStepContextMap>;
+    const currentState = (router.history[router.currentIndex] ?? options.initial) as FunnelStateByContextMap<TStepContextMap>;
     const currentStateRef = useUpdatableRef(currentState);
 
     const parseStepContext = useCallback(


### PR DESCRIPTION
add a fallback for funnel state when adapter history array is empty.