### PR TITLE
fix(next): Keep current history context at refresh

### DIFF
--- a/.changeset/tame-adults-teach.md
+++ b/.changeset/tame-adults-teach.md
@@ -1,0 +1,10 @@
+---
+'@use-funnel/core': patch
+'@use-funnel/next': patch
+'@use-funnel/browser': patch
+'@use-funnel/react-navigation-native': patch
+'@use-funnel/react-router-dom': patch
+---
+
+fix(next): Keep current history context at refresh
+fix(core): Fix useFunnelRouter using initial optionRef

--- a/packages/core/src/useFunnel.tsx
+++ b/packages/core/src/useFunnel.tsx
@@ -34,8 +34,8 @@ export interface UseFunnel<TRouteOption extends RouteOption> {
     TStepKeys extends keyof _TStepContextMap = keyof _TStepContextMap,
     TStepContext extends _TStepContextMap[TStepKeys] = _TStepContextMap[TStepKeys],
     TStepContextMap extends string extends keyof _TStepContextMap
-    ? Record<TStepKeys, TStepContext>
-    : _TStepContextMap = string extends keyof _TStepContextMap ? Record<TStepKeys, TStepContext> : _TStepContextMap,
+      ? Record<TStepKeys, TStepContext>
+      : _TStepContextMap = string extends keyof _TStepContextMap ? Record<TStepKeys, TStepContext> : _TStepContextMap,
   >(
     options: UseFunnelOptions<TStepContextMap>,
   ): UseFunnelResults<TStepContextMap, TRouteOption>;
@@ -49,15 +49,16 @@ export function createUseFunnel<TRouteOption extends RouteOption>(
     TStepKeys extends keyof _TStepContextMap = keyof _TStepContextMap,
     TStepContext extends _TStepContextMap[TStepKeys] = _TStepContextMap[TStepKeys],
     TStepContextMap extends string extends keyof _TStepContextMap
-    ? Record<TStepKeys, TStepContext>
-    : _TStepContextMap = string extends keyof _TStepContextMap ? Record<TStepKeys, TStepContext> : _TStepContextMap,
+      ? Record<TStepKeys, TStepContext>
+      : _TStepContextMap = string extends keyof _TStepContextMap ? Record<TStepKeys, TStepContext> : _TStepContextMap,
   >(options: UseFunnelOptions<TStepContextMap>): UseFunnelResults<TStepContextMap, TRouteOption> {
     const optionsRef = useUpdatableRef(options);
     const router = useFunnelRouter({
-      id: options.id,
-      initialState: options.initial,
+      id: optionsRef.current.id,
+      initialState: optionsRef.current.initial,
     });
-    const currentState = (router.history[router.currentIndex] ?? options.initial) as FunnelStateByContextMap<TStepContextMap>;
+    const currentState = (router.history[router.currentIndex] ??
+      options.initial) as FunnelStateByContextMap<TStepContextMap>;
     const currentStateRef = useUpdatableRef(currentState);
 
     const parseStepContext = useCallback(
@@ -85,16 +86,16 @@ export function createUseFunnel<TRouteOption extends RouteOption>(
           typeof assignContext === 'function'
             ? assignContext(currentStateRef.current.context)
             : {
-              ...currentStateRef.current.context,
-              ...assignContext,
-            };
+                ...currentStateRef.current.context,
+                ...assignContext,
+              };
         const context = parseStepContext(step, newContext);
         return context == null
           ? optionsRef.current.initial
           : ({
-            step,
-            context,
-          } as FunnelStateByContextMap<TStepContextMap>);
+              step,
+              context,
+            } as FunnelStateByContextMap<TStepContextMap>);
       };
       return {
         push: async (...args) => {
@@ -120,9 +121,9 @@ export function createUseFunnel<TRouteOption extends RouteOption>(
         ...(validContext == null
           ? optionsRef.current.initial
           : {
-            step: currentState.step,
-            context: validContext,
-          }),
+              step: currentState.step,
+              context: validContext,
+            }),
         history,
         index: router.currentIndex,
         historySteps: router.history as FunnelStateByContextMap<TStepContextMap>[],

--- a/packages/next/test/index.test.tsx
+++ b/packages/next/test/index.test.tsx
@@ -1,8 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { describe, expect, test } from 'vitest';
 import mockRouter from 'next-router-mock';
-
+import { describe, expect, test } from 'vitest';
 import { useFunnel } from '../src/index.js';
 
 describe('Test useFunnel next router', () => {
@@ -19,6 +18,8 @@ describe('Test useFunnel next router', () => {
           context: {},
         },
       });
+
+      console.log(funnel);
 
       switch (funnel.step) {
         case 'A': {
@@ -67,19 +68,16 @@ describe('Test useFunnel next router', () => {
     await user.click(screen.getByText('Go B'));
 
     expect(screen.queryByText('vitest')).not.toBeNull();
-    expect(mockRouter.query['funnel.vitest.index']).toBe(1);
-    expect(JSON.parse(mockRouter.query['funnel.vitest.histories'] as string)).toEqual([
-      { step: 'A', context: {} },
-      { step: 'B', context: { id: 'vitest' } },
-    ]);
+    expect(mockRouter.query['funnel.vitest.step']).toBe('B');
+    expect(JSON.parse(mockRouter.query['funnel.vitest.context'] as string)).toEqual({
+      id: 'vitest',
+    });
+    expect(JSON.parse(mockRouter.query['funnel.vitest.histories'] as string)).toEqual([{ step: 'A', context: {} }]);
 
     await user.click(screen.getByText('Go C'));
 
     expect(screen.queryByText('Finished!')).not.toBeNull();
-    expect(mockRouter.query['funnel.vitest.index']).toBe(1);
-    expect(JSON.parse(mockRouter.query['funnel.vitest.histories'] as string)).toEqual([
-      { step: 'A', context: {} },
-      { step: 'C', context: { id: 'vitest', password: 'vitest1234' } },
-    ]);
+    expect(mockRouter.query['funnel.vitest.step']).toBe('C');
+    expect(JSON.parse(mockRouter.query['funnel.vitest.histories'] as string)).toEqual([{ step: 'A', context: {} }]);
   });
 });

--- a/packages/next/test/index.test.tsx
+++ b/packages/next/test/index.test.tsx
@@ -19,8 +19,6 @@ describe('Test useFunnel next router', () => {
         },
       });
 
-      console.log(funnel);
-
       switch (funnel.step) {
         case 'A': {
           return (


### PR DESCRIPTION
close #67 
close #63 

* Change funnel state save architecture
  * Using query string to save current step & context
  * Using history.state to save "before histories"