### PR TITLE
fix(browser): duplicate sub funnel ids renders incorrect step.

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -8,9 +8,18 @@ export const useFunnel = createUseFunnel(({ id, initialState }) => {
   const [location, setLocation] = useState(() => ({
     search: typeof window !== 'undefined' ? window.location.search : '',
   }));
-  const [state, setState] = useState(() => ({
-    ...(typeof window !== 'undefined' ? window.history.state : {}),
-  }));
+  const [state, setState] = useState(() => {
+    if (typeof window === 'undefined') {
+      return {};
+    }
+
+    const isSubFunnelIdDuplicated = window.history.state[`${id}.histories`];
+    if (isSubFunnelIdDuplicated) {
+      console.error(`Duplicate sub funnel ids detected in main funnel. This may cause unexpected step rendering.`);
+    }
+
+    return window.history.state;
+  });
 
   useEffect(() => {
     function handlePopState(event: PopStateEvent) {

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -4,6 +4,17 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export * from '@use-funnel/core';
 
+function unmountFunnel(id: string) {
+  const newHistoryState = {
+    ...window.history.state,
+  };
+
+  delete newHistoryState[`${id}.context`];
+  delete newHistoryState[`${id}.histories`];
+
+  window.history.replaceState(newHistoryState, '');
+}
+
 export const useFunnel = createUseFunnel(({ id, initialState }) => {
   const [location, setLocation] = useState(() => ({
     search: typeof window !== 'undefined' ? window.location.search : '',
@@ -28,6 +39,7 @@ export const useFunnel = createUseFunnel(({ id, initialState }) => {
     }
     window.addEventListener('popstate', handlePopState);
     return () => {
+      unmountFunnel(id);
       window.removeEventListener('popstate', handlePopState);
     };
   }, []);


### PR DESCRIPTION
#94

I suggest showing console error messages to prevent duplicate sub funnel ids, and clearing the `window.history.state` after the sub funnel component unmounts.