### PR TITLE
feat(docs): add Documentation for Potential Hydration Issues with @use-funnel/browser in App Router

### DIFF
--- a/docs/src/components/UseFunnelCodeBlock.tsx
+++ b/docs/src/components/UseFunnelCodeBlock.tsx
@@ -25,7 +25,7 @@ export const useFunnelPackages = [
 ];
 
 interface UseFunnelCodeBlockProps {
-  renderSupplement?: ({ packageName }: { packageName: string }) => React.ReactNode;
+  renderSupplement?: ({ packageTitle }: { packageTitle: string }) => React.ReactNode;
 }
 
 export function UseFunnelCodeBlock({
@@ -37,7 +37,7 @@ export function UseFunnelCodeBlock({
       {useFunnelPackages.map((item) => (
         <Tabs.Tab key={item.packageTitle}>
           <UseFunnelImportReplace packageName={item.packageName}>{children}</UseFunnelImportReplace>
-          {RenderSupplement && <RenderSupplement packageName={item.packageName} />}
+          {RenderSupplement && <RenderSupplement packageTitle={item.packageTitle} />}
         </Tabs.Tab>
       ))}
     </Tabs>

--- a/docs/src/components/UseFunnelCodeBlock.tsx
+++ b/docs/src/components/UseFunnelCodeBlock.tsx
@@ -3,6 +3,10 @@ import { useEffect, useRef } from 'react';
 
 export const useFunnelPackages = [
   {
+    packageName: 'browser',
+    packageTitle: 'Next.js app router',
+  },
+  {
     packageName: 'next',
     packageTitle: 'Next.js page router',
   },
@@ -20,12 +24,20 @@ export const useFunnelPackages = [
   },
 ];
 
-export function UseFunnelCodeBlock({ children }: React.PropsWithChildren<unknown>) {
+interface UseFunnelCodeBlockProps {
+  renderSupplement?: ({ packageName }: { packageName: string }) => React.ReactNode;
+}
+
+export function UseFunnelCodeBlock({
+  children,
+  renderSupplement: RenderSupplement,
+}: React.PropsWithChildren<UseFunnelCodeBlockProps>) {
   return (
     <Tabs items={useFunnelPackages.map((p) => p.packageTitle)} storageKey="favorite-package">
       {useFunnelPackages.map((item) => (
         <Tabs.Tab key={item.packageTitle}>
           <UseFunnelImportReplace packageName={item.packageName}>{children}</UseFunnelImportReplace>
+          {RenderSupplement && <RenderSupplement packageName={item.packageName} />}
         </Tabs.Tab>
       ))}
     </Tabs>

--- a/docs/src/pages/docs/get-started.en.mdx
+++ b/docs/src/pages/docs/get-started.en.mdx
@@ -1,5 +1,5 @@
 import { Steps, Callout } from 'nextra/components'
-import { UseFunnelCodeBlock, Keyword } from '@/components'
+import { UseFunnelCodeBlock, Keyword, useFunnelPackages } from '@/components'
 
 # Getting Started
 
@@ -35,7 +35,28 @@ First, specify the object type with the key as the step and the context object a
 
 Here, we set the initial step to "EmailInput" and an empty `context` object to be used in that step. `id` is a unique identifier to distinguish when there are multiple funnels in one component.
 
-<UseFunnelCodeBlock>
+<UseFunnelCodeBlock
+  renderSupplement={({ packageName }) => {
+    if (packageName === useFunnelPackages[0].packageName) {
+      return (
+        <Callout type="warning">
+          <strong>Note:</strong> Since <code>@use-funnel/browser</code> relies on the browser's history
+          state, it cannot be hydrated on the server. This means it must run exclusively on the client. To make sure 
+          it works correctly, you can either render it conditionally after mounting in a parent component or use a{' '}
+          <code>ssr: false</code> configuration with{' '}
+          <a
+            href="https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#nextdynamic"
+            target="_blank"
+            rel="noreferrer"
+          >
+            next/dynamic
+          </a>{' '}
+          to create the funnel component.
+        </Callout>
+      );
+    }
+  }}
+>
 ```tsx {5-15}
 import { useFunnel } from "@use-funnel/next";
 import type { EmailInput, PasswordInput, OtherInfoInput } "./context";

--- a/docs/src/pages/docs/get-started.en.mdx
+++ b/docs/src/pages/docs/get-started.en.mdx
@@ -36,8 +36,8 @@ First, specify the object type with the key as the step and the context object a
 Here, we set the initial step to "EmailInput" and an empty `context` object to be used in that step. `id` is a unique identifier to distinguish when there are multiple funnels in one component.
 
 <UseFunnelCodeBlock
-  renderSupplement={({ packageName }) => {
-    if (packageName === useFunnelPackages[0].packageName) {
+  renderSupplement={({ packageTitle }) => {
+    if (packageTitle === useFunnelPackages[0].packageTitle) {
       return (
         <Callout type="warning">
           <strong>Note:</strong> Since <code>@use-funnel/browser</code> relies on the browser's history

--- a/docs/src/pages/docs/get-started.ko.mdx
+++ b/docs/src/pages/docs/get-started.ko.mdx
@@ -36,8 +36,8 @@ type 그외정보입력 = { email: string; password: string; other?: unknown }
 여기서는 초기 단계인 "이메일입력"과 해당 단계에서 사용할 빈 `context` 객체를 설정했어요. `id`는 [한 컴포넌트에 여러 퍼널](/docs/sub-funnel)이 있을 때 구분하기 위한 고유 식별자에요.
 
 <UseFunnelCodeBlock
-  renderSupplement={({ packageName }) => {
-    if (packageName === useFunnelPackages[0].packageName) {
+  renderSupplement={({ packageTitle }) => {
+    if (packageTitle === useFunnelPackages[0].packageTitle) {
       return (
         <Callout type="warning">
             <strong>주의할 점:</strong> <code>@use-funnel/browser</code>의 경우 브라우저의 히스토리 상태를 기반으로

--- a/docs/src/pages/docs/get-started.ko.mdx
+++ b/docs/src/pages/docs/get-started.ko.mdx
@@ -1,5 +1,5 @@
 import { Steps, Callout } from 'nextra/components'
-import { UseFunnelCodeBlock, Keyword } from '@/components'
+import { UseFunnelCodeBlock, Keyword, useFunnelPackages } from '@/components'
 
 # 시작하기
 
@@ -35,7 +35,27 @@ type 그외정보입력 = { email: string; password: string; other?: unknown }
 
 여기서는 초기 단계인 "이메일입력"과 해당 단계에서 사용할 빈 `context` 객체를 설정했어요. `id`는 [한 컴포넌트에 여러 퍼널](/docs/sub-funnel)이 있을 때 구분하기 위한 고유 식별자에요.
 
-<UseFunnelCodeBlock>
+<UseFunnelCodeBlock
+  renderSupplement={({ packageName }) => {
+    if (packageName === useFunnelPackages[0].packageName) {
+      return (
+        <Callout type="warning">
+            <strong>주의할 점:</strong> <code>@use-funnel/browser</code>의 경우 브라우저의 히스토리 상태를 기반으로
+            동작하기 때문에 서버에서 <code>Hydration</code>을 기대하기 어려워요. 그래서 오로지 클라이언트에서만 실행될 수 있도록 상위
+            컴포넌트에서 <code>mount</code>후에 렌더링 하게하거나,{' '}
+            <a
+              href="https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#nextdynamic"
+              target="_blank"
+              rel="noreferrer"
+            >
+              next/dynamic
+            </a>
+            의 컴포넌트를 통해 <code>ssr: false</code> 형태로 퍼널 컴포넌트를 만들어야해요.
+        </Callout>
+      );
+    }
+  }}
+>
 ```tsx {5-15}
 import { useFunnel } from "@use-funnel/next";
 import type { 이메일입력, 비밀번호입력, 그외정보입력 } "./context";

--- a/docs/src/pages/docs/sub-funnel.en.mdx
+++ b/docs/src/pages/docs/sub-funnel.en.mdx
@@ -1,4 +1,4 @@
-import { UseFunnelCodeBlock, Keyword, Sandpack } from '@/components'
+import { Keyword, Sandpack } from '@/components'
 
 # Creating a Funnel within a Funnel
 

--- a/docs/src/pages/docs/sub-funnel.ko.mdx
+++ b/docs/src/pages/docs/sub-funnel.ko.mdx
@@ -1,4 +1,4 @@
-import { UseFunnelCodeBlock, Keyword, Sandpack } from '@/components'
+import { Keyword, Sandpack } from '@/components'
 
 # 퍼널 안에 퍼널 만들기
 

--- a/docs/src/pages/docs/use-funnel.en.mdx
+++ b/docs/src/pages/docs/use-funnel.en.mdx
@@ -114,6 +114,13 @@ interface FunnelHistory<TContextMap, TCurrentStep extends keyof TContextMap> {
 <Tabs items={useFunnelPackages.map((p) => p.packageTitle)} storageKey="favorite-package">
   <Tabs.Tab>
     ```ts
+    interface RouteOption {}
+    ```
+
+    At this package, no options are provided.
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
     interface RouteOption {
       scroll?: boolean;
       locale?: string;

--- a/docs/src/pages/docs/use-funnel.ko.mdx
+++ b/docs/src/pages/docs/use-funnel.ko.mdx
@@ -111,6 +111,13 @@ interface FunnelHistory<TContextMap, TCurrentStep extends keyof TContextMap> {
 <Tabs items={useFunnelPackages.map((p) => p.packageTitle)} storageKey="favorite-package">
   <Tabs.Tab>
     ```ts
+    interface RouteOption {}
+    ```
+
+    해당 패키지에서는 옵션을 제공하고 있지 않아요.
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
     interface RouteOption {
       scroll?: boolean;
       locale?: string;


### PR DESCRIPTION
ISSUE: https://github.com/toss/use-funnel/issues/104

## `get-started` Page

### KR
<img width="521" alt="스크린샷 2025-01-26 오후 5 10 13" src="https://github.com/user-attachments/assets/8e5d4e57-ac0c-44ba-acc9-79dff1524170" />

### EN
<img width="517" alt="스크린샷 2025-01-26 오후 5 10 54" src="https://github.com/user-attachments/assets/84f25ee9-d172-49d9-a653-e5d8fe9404be" />

## `use-funnel` Page

### KR
<img width="558" alt="스크린샷 2025-01-26 오후 5 11 59" src="https://github.com/user-attachments/assets/fc6b4f27-b168-45df-9e94-f91d3c4c0094" />

### EN
<img width="557" alt="스크린샷 2025-01-26 오후 5 12 13" src="https://github.com/user-attachments/assets/87c226aa-aa6e-44de-95e7-7aaa0216a439" />

## Additional Question

The English `funnel-render` page provides a tab view using the `UseFunnelCodeBlock` component. However, the Korean page does not. If this is an oversight, would it be acceptable to apply the `UseFunnelCodeBlock` component to the Korean `funnel-render` page as part of this PR?

### KR
<img width="560" alt="스크린샷 2025-01-26 오후 5 26 24" src="https://github.com/user-attachments/assets/3ec8c154-712a-4c10-ab35-ff46f28df7b8" />


### EN
<img width="556" alt="스크린샷 2025-01-26 오후 5 26 13" src="https://github.com/user-attachments/assets/0d026f80-ba7e-43cd-b655-fa26702ba7dd" />



