### PR TITLE
fix(docs): prevent duplicate package name replacement in UseFunnelImportReplace

### DIFF
--- a/docs/src/components/UseFunnelCodeBlock.tsx
+++ b/docs/src/components/UseFunnelCodeBlock.tsx
@@ -65,15 +65,15 @@ function UseFunnelImportReplace({
         .forEach((line) => {
           const tokens = Array.from(line.querySelectorAll('[style*="token-string-expression"]'));
           tokens.forEach((token) => {
-            for (const targetPackage of useFunnelPackages) {
-              if (token.textContent?.includes(targetPackage.packageName)) {
-                const content = token.textContent.replace(/['"]/g, '');
-                const [prefix, packagePath] = content.split('@use-funnel/');
+            const matchingPackage = useFunnelPackages.find((pkg) => token.textContent?.includes(pkg.packageName));
 
-                if (packagePath === targetPackage.packageName) {
-                  token.textContent = `"${prefix}@use-funnel/${packageName}"`;
-                }
-              }
+            if (!matchingPackage || !token.textContent) return;
+
+            const content = token.textContent.replace(/['"]/g, '');
+            const [prefix, packagePath] = content.split('@use-funnel/');
+
+            if (packagePath === matchingPackage.packageName) {
+              token.textContent = `"${prefix}@use-funnel/${packageName}"`;
             }
           });
         });

--- a/docs/src/components/UseFunnelCodeBlock.tsx
+++ b/docs/src/components/UseFunnelCodeBlock.tsx
@@ -67,7 +67,12 @@ function UseFunnelImportReplace({
           tokens.forEach((token) => {
             for (const targetPackage of useFunnelPackages) {
               if (token.textContent?.includes(targetPackage.packageName)) {
-                token.textContent = token.textContent.replace(targetPackage.packageName, packageName);
+                const content = token.textContent.replace(/['"]/g, '');
+                const [prefix, packagePath] = content.split('@use-funnel/');
+
+                if (packagePath === targetPackage.packageName) {
+                  token.textContent = `"${prefix}@use-funnel/${packageName}"`;
+                }
               }
             }
           });


### PR DESCRIPTION
**description**
The UseFunnelImportReplace component had a bug where package names that were
substrings of other package names (e.g. 'react-router' in 'react-router-dom')
were being incorrectly replaced, resulting in invalid package names like 'react-router-dom-dom'

**Change Includes**
- Removes quotes from package path string
- Splits the path into segments
- Only replaces the exact package name match
- Replace for loop with Array.find() for better performance and readability
- Improve variable naming for better code clarity

**AS-IS**
![AS-IS](https://github.com/user-attachments/assets/46ac1105-80ed-49eb-9119-e2632a1b4de9)

**TO-BE**
![TO-BE](https://github.com/user-attachments/assets/31bd64e1-5d15-471d-acf0-2595a52b1c0f)