### PR TITLE
docs: add missing cleanup params on custom router

### DIFF
--- a/docs/src/pages/docs/custom-router.en.mdx
+++ b/docs/src/pages/docs/custom-router.en.mdx
@@ -45,6 +45,10 @@ export const useFunnel = createUseFunnel(({ id, initialState }) => {
       go(delta) {
         setCurrentIndex((prev) => prev + delta);
       },
+      // cleanup function is called when the funnel unmounts.
+      cleanup() {
+        
+      },
     }),
     [history, currentIndex] // Returns memoized values whenever history and currentIndex change.
   );

--- a/docs/src/pages/docs/custom-router.ko.mdx
+++ b/docs/src/pages/docs/custom-router.ko.mdx
@@ -45,6 +45,10 @@ export const useFunnel = createUseFunnel(({ id, initialState }) => {
       go(delta) {
         setCurrentIndex((prev) => prev + delta);
       },
+      // cleanup 함수는 funnel이 언마운트될 때 호출돼요.
+      cleanup() {
+        
+      },
     }),
     [history, currentIndex], // history와 currentIndex가 변경될 때마다 메모이제이션된 값을 반환해요.
   );


### PR DESCRIPTION
Thanks for great library. 

I got error below following the current docs which is missing `cleanup` function on description. 

<img width="434" alt="Screenshot 2025-02-23 at 4 37 53 PM" src="https://github.com/user-attachments/assets/da6579ce-caab-4a5e-929e-cf785348979c" />

Fixing docs. 
