### PR TITLE
chore(package.json): simplify packageManager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,5 @@
       "git add"
     ]
   },
-  "packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e"
+  "packageManager": "pnpm@9.6.0"
 }


### PR DESCRIPTION
* The hash information (SHA) is not necessary for communication within the team or for managing change history. In fact, the version `pnpm@9.6.0` is sufficient to identify the specific version.