### PR TITLE
chore(package.json): remove 'git add' command in 'lint-staged' configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,10 @@
   },
   "lint-staged": {
     "packages/*/{src,test}/*.{js,jsx,ts,tsx,md}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "packages/*/{src,test}/*.{js,ts,tsx}": [
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ]
   },
   "packageManager": "pnpm@9.6.0"


### PR DESCRIPTION
## Description

This PR removes the redundant `git add` command from the `lint-staged` configuration. Since `lint-staged` automatically works with files that are already staged, adding `git add` after running `prettier` and `eslint` is unnecessary.

## Changes
* Removed the `git add` command from the `lint-staged` configuration.

## Why?
* `git add` is not needed in this context because lint-staged operates on files that are already staged.
* This simplifies the configuration and avoids redundant operations.