### PR TITLE
fix(next): next router cleanup check querystring without router

### DIFF
--- a/.changeset/forty-cars-fold.md
+++ b/.changeset/forty-cars-fold.md
@@ -1,0 +1,5 @@
+---
+'@use-funnel/next': patch
+---
+
+fix(next): next router cleanup check querystring without router

--- a/examples/nextjs-pages-router/e2e/pages-router-funnel.spec.ts
+++ b/examples/nextjs-pages-router/e2e/pages-router-funnel.spec.ts
@@ -5,17 +5,30 @@ const PAGES_ROUTER_LOCAL_URL = 'http://localhost:3101/';
 test('can move the steps of the funnel using history.push.', async ({ page }) => {
   await page.goto(PAGES_ROUTER_LOCAL_URL);
 
-  await expect(page.getByText('start')).toBeVisible();
+  // start
+  await expect(page.getByRole('heading', { name: 'start' })).toBeVisible();
 
   await expect(page.getByRole('button', { name: 'next' })).toBeVisible();
 
   await page.getByRole('button', { name: 'next' }).click();
 
-  await expect(page.getByText('end')).toBeVisible();
+  // middle
+  await expect(page.getByRole('heading', { name: 'sub start' })).toBeVisible();
+
+  await expect(page.getByRole('button', { name: 'next' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'next' }).click();
+
+  await expect(page.getByRole('heading', { name: 'sub end' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'next' }).click();
+
+  // end
+  await expect(page.getByRole('heading', { name: 'end' })).toBeVisible();
 
   await page.goBack();
 
-  await expect(page.getByText('start')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'sub end' })).toBeVisible();
 });
 
 test('can move the steps of the funnel using Link.', async ({ page }) => {
@@ -23,5 +36,16 @@ test('can move the steps of the funnel using Link.', async ({ page }) => {
 
   await page.getByRole('link', { name: 'Go Home' }).click();
 
-  await expect(page.getByText('Home')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
+
+  await page.goBack();
+
+  await expect(page.getByRole('heading', { name: 'start' })).toBeVisible();
+
+  await expect(page.getByRole('button', { name: 'next' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'next' }).click();
+
+  // middle
+  await expect(page.getByRole('heading', { name: 'sub start' })).toBeVisible();
 });

--- a/examples/nextjs-pages-router/src/funnel.tsx
+++ b/examples/nextjs-pages-router/src/funnel.tsx
@@ -9,23 +9,54 @@ export const TestPagesRouterFunnel = () => {
       <funnel.Render
         start={({ history }) => (
           <div>
-            <p>start</p>
+            <h1>start</h1>
 
-            <button onClick={() => history.push('end')}>next</button>
+            <button onClick={() => history.push('middle')}>next</button>
           </div>
         )}
-        end={() => <div>end</div>}
+        middle={({ history }) => {
+          return <SubFunnel onNext={() => history.push('end')} />;
+        }}
+        end={() => <h1>end</h1>}
       />
     </>
   );
 };
 
+function SubFunnel({ onNext }: { onNext: () => void }) {
+  const funnel = useFunnel<{
+    start: StartProps;
+    end: EndProps;
+  }>({ id: 'sub-funnel', initial: { step: 'start', context: {} } });
+  return (
+    <div>
+      <h1>sub-funnel</h1>
+      <funnel.Render
+        start={({ history }) => (
+          <div>
+            <h2>sub start</h2>
+            <button onClick={() => history.push('end')}>next</button>
+          </div>
+        )}
+        end={() => (
+          <div>
+            <h2>sub end</h2>
+            <button onClick={() => onNext()}>next</button>
+          </div>
+        )}
+      />
+    </div>
+  );
+}
+
 const FUNNEL_ID = 'test-pages-router-funnel';
 
 type StartProps = {};
+type MiddleProps = {};
 type EndProps = {};
 
 type FunnelState = {
   start: StartProps;
+  middle: MiddleProps;
   end: EndProps;
 };


### PR DESCRIPTION
Issue #119 reoccurs when funnels are nested.
The cause was that cleanup was happening multiple times and the value of router.query was not persisted in the parent funnel.

In the following, we make sure that cleanup checks with the value of window.location.search.
