### PR TITLE
fix(next): handle objects without hasOwnProperty in stringifyQueryJson

### DIFF
--- a/packages/next/src/util.ts
+++ b/packages/next/src/util.ts
@@ -47,7 +47,13 @@ export function stringifyQueryJson(data: unknown) {
   return JSON.stringify(data, (_, value) => {
     if (typeof value === 'object' && value != null) {
       for (const key in value) {
-        if (value.hasOwnProperty(key)) {
+        /**
+         * Safe hasOwnProperty check for objects that don't inherit from Object.prototype.
+         * Uses call() to invoke hasOwnProperty from Object.prototype directly,
+         * avoiding TypeError when object doesn't inherit from Object.prototype.
+         * @see https://github.com/toss/use-funnel/issues/152
+         */
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
           if (value[key] instanceof Date) {
             value[key] = {
               __type: 'Date',

--- a/packages/next/test/util.test.ts
+++ b/packages/next/test/util.test.ts
@@ -34,10 +34,20 @@ describe('Test makePath', () => {
 });
 
 describe('Test stringifyQueryJson', () => {
-  test('should work', async () => {
+  test('should work with date', async () => {
     const value = { a: 1, b: new Date('2025-04-15T14:28:09.987Z') };
 
     expect(stringifyQueryJson(value)).toEqual('{"a":1,"b":{"__type":"Date","value":"2025-04-15T14:28:09.987Z"}}');
+  });
+
+  test('should work with objects that do not inherit from Object.prototype', async () => {
+    const objectWithoutPrototype = Object.create(null);
+    objectWithoutPrototype.a = 1;
+    objectWithoutPrototype.b = 2;
+
+    const value = { a: 1, c: objectWithoutPrototype };
+
+    expect(stringifyQueryJson(value)).toEqual('{"a":1,"c":{"a":1,"b":2}}');
   });
 });
 


### PR DESCRIPTION
## Fixes
- Closes #152


## Problem
The `stringifyQueryJson` function crashes when processing objects that don't inherit from `Object.prototype`, such as:
- Objects created with `Object.create(null)`
- Headers returned by axios
- Objects from external libraries without standard prototype chain

**Error:** `TypeError: value.hasOwnProperty is not a function`

## Root Cause
The function directly calls `value.hasOwnProperty(key)`, which fails when the object doesn't have this method in its prototype chain.

```javascript
// Problematic code
if (value.hasOwnProperty(key)) { // TypeError when hasOwnProperty doesn't exist
```

## Solution
Replace direct method call with `Object.prototype.hasOwnProperty.call()` to safely check property ownership regardless of the object's prototype chain.

```javascript
// Safe approach
if (Object.prototype.hasOwnProperty.call(value, key)) {
```

## Changes
- ✅ Use `Object.prototype.hasOwnProperty.call()` for safe property checking
- ✅ Maintains existing functionality for normal objects
- ✅ Now handles prototype-less objects without crashing

## Testing
- [x] Existing tests pass
- [x] Added test case for `Object.create(null)` objects
- [x] Verified compatibility with axios headers
- [x] Date serialization still works correctly


---

**Before:** Function crashes with axios headers or `Object.create(null)` objects  
**After:** Function safely processes all object types while maintaining Date serialization