### PR TITLE
feature(next): add suspense option

### DIFF
--- a/.changeset/hot-candles-drive.md
+++ b/.changeset/hot-candles-drive.md
@@ -1,0 +1,5 @@
+---
+'@use-funnel/next': patch
+---
+
+next: add suspense option

--- a/packages/next/src/useFunnel.tsx
+++ b/packages/next/src/useFunnel.tsx
@@ -1,6 +1,6 @@
 import { createUseFunnel } from '@use-funnel/core';
-import { useRouter } from 'next/router.js';
 import { useMemo, useRef } from 'react';
+import { useNextRouter } from './useNextRouter';
 import { makePath, parseQueryJson, removeKeys, stringifyQueryJson } from './util';
 
 const QS_KEY = 'funnel.';
@@ -23,6 +23,7 @@ interface NextPageFunnelOption {
   stepQueryName?: (id: string) => string;
   contextQueryName?: (id: string) => string;
   historyQueryName?: (id: string) => string;
+  suspense?: boolean;
 }
 
 export const useFunnel = createUseFunnel<NextPageRouteOption, NextPageFunnelOption>(({
@@ -32,8 +33,9 @@ export const useFunnel = createUseFunnel<NextPageRouteOption, NextPageFunnelOpti
   stepQueryName = (id) => `${QS_KEY}${id}${STEP_KEY}`,
   contextQueryName = (id) => `${QS_KEY}${id}${CONTEXT_KEY}`,
   historyQueryName = (id) => `${QS_KEY}${id}${HISTORY_KEY}`,
+  suspense,
 }) => {
-  const router = useRouter();
+  const router = useNextRouter({ suspense });
 
   const routerRef = useRef(router);
   routerRef.current = router;

--- a/packages/next/src/useNextRouter.ts
+++ b/packages/next/src/useNextRouter.ts
@@ -5,7 +5,7 @@ interface Options {
   suspense?: boolean;
 }
 
-export function useNextRouter(options: Options = { suspense: true }) {
+export function useNextRouter(options: Options = { suspense: false }) {
   const router = useRouter();
 
   if (options.suspense && !router.isReady) {

--- a/packages/next/src/useNextRouter.ts
+++ b/packages/next/src/useNextRouter.ts
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router.js';
+import { waitForRouterReady } from './util';
+
+interface Options {
+  suspense?: boolean;
+}
+
+export function useNextRouter(options: Options = { suspense: true }) {
+  const router = useRouter();
+
+  if (options.suspense && !router.isReady) {
+    throw waitForRouterReady();
+  }
+
+  return router;
+}

--- a/packages/next/src/util.ts
+++ b/packages/next/src/util.ts
@@ -1,4 +1,4 @@
-import { NextRouter } from 'next/router';
+import Router, { NextRouter } from 'next/router';
 
 export const removeKeys = (_value: Record<string, any>, conditions: (string | ((key: string) => boolean))[]) => {
   const value = { ..._value };
@@ -64,5 +64,11 @@ export function stringifyQueryJson(data: unknown) {
       }
     }
     return value;
+  });
+}
+
+export function waitForRouterReady() {
+  return new Promise<void>((resolve) => {
+    Router.ready(resolve);
   });
 }

--- a/packages/next/test/utils.tsx
+++ b/packages/next/test/utils.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import { ReactNode, Suspense, useEffect } from 'react';
+import { vi } from 'vitest';
+
+export function renderWithSuspense() {
+  const isSuspended = vi.fn(() => null);
+
+  const FallbackComponent = ({ children }: { children: ReactNode }) => {
+    isSuspended();
+    return <>{children}</>;
+  };
+
+  const withSuspense = (children: ReactNode, { fallback }: { fallback: ReactNode }) => {
+    return <Suspense fallback={<FallbackComponent>{fallback}</FallbackComponent>}>{children}</Suspense>;
+  };
+
+  return {
+    withSuspense,
+    checkDidSuspend: () => isSuspended.mock.calls.length > 0,
+  };
+}


### PR DESCRIPTION
Adds support for waiting for the isReady state of the Next.js router using the suspense option.
When suspense is set to true, the component must be wrapped in a Suspense boundary.