### PR TITLE
fix(react-navigation-native): prevent navigation warning by skipping setParams on unfocused screens

### DIFF
--- a/packages/react-navigation-native/src/index.ts
+++ b/packages/react-navigation-native/src/index.ts
@@ -207,6 +207,10 @@ export const useFunnel = createUseFunnel(({ id, initialState }) => {
         }
       },
       cleanup() {
+        if (!navigation.isFocused()) {
+          return;
+        }
+
         const newUseFunnelState = { ...useFunnelState };
 
         if (newUseFunnelState[id] == null) {


### PR DESCRIPTION
Updated the code to resolve the related #162 .