### PR TITLE
docs(HomePage.tsx): modified HomePage for tablet, mobile screen

### DIFF
--- a/docs/src/components/HomePage.tsx
+++ b/docs/src/components/HomePage.tsx
@@ -14,12 +14,12 @@ export const HomePage = ({
 }) => {
   return (
     <div className="flex md:h-[calc(100vh-162px)] pt-12">
-      <div className="flex flex-col md:h-full md:mr-8">
-        <div className="flex flex-col flex-1 md:mb-0 mb-12">
+      <div className="flex flex-col md:h-full md:mr-8 flex-1">
+        <div className="flex flex-col xl:flex-1 md:mb-0 mb-3">
           <Image src="/logo.png" alt="@use-funnel logo" width={140} height={140} />
-          <h1 className="flex flex-col gap-4 mb-12">
-            <strong className="relative text-6xl font-bold">{title}</strong>
-            <p className="text-2xl leading-normal break-words">{description}</p>
+          <h1 className="flex flex-col gap-4 mb-6">
+            <strong className="relative text-6xl max-md:text-4xl font-bold">{title}</strong>
+            <p className="text-2xl max-lg:text-xl leading-normal break-words">{description}</p>
           </h1>
           <div>
             <Link href="/docs/overview">
@@ -30,12 +30,9 @@ export const HomePage = ({
           </div>
         </div>
 
-        <div className="flex md:flex-row flex-col justify-between gap-8 items-stretch">
+        <div className="flex mt-6 flex-col xl:flex-row justify-between gap-8 items-stretch">
           {items.map(({ title, desc }) => (
-            <div
-              className="flex flex-1 flex-col items-start gap-3 bg-opacity-10 bg-slate-500 rounded-lg py-4 px-6"
-              key={title}
-            >
+            <div className="flex flex-1 flex-col items-start gap-3 bg-slate-500/10 rounded-lg py-4 px-6" key={title}>
               <div className="text-xl font-bold opacity-80">{title}</div>
               <p className="text-base whitespace-break-spaces opacity-60">{desc}</p>
             </div>
@@ -44,7 +41,7 @@ export const HomePage = ({
       </div>
 
       <video
-        className="float-right max-w-[40%] invert-video hidden md:block rounded-lg "
+        className="max-w-[40%] flex-shrink-0 invert-video hidden md:block rounded-lg"
         src="/example.mp4"
         poster="/overlay.png"
         height="100%"

--- a/docs/src/pages/docs/sub-funnel.en.mdx
+++ b/docs/src/pages/docs/sub-funnel.en.mdx
@@ -1,46 +1,49 @@
-import { Keyword, Sandpack } from '@/components'
+import { Keyword, Sandpack } from '@/components';
 
 # Creating a Funnel within a Funnel
 
 When developing a funnel, you may need to go through multiple steps to achieve a particular state. Alternatively, you might need to reuse a portion of the funnel steps in another context. In these situations, dividing the funnel into sub-funnels can be an efficient approach. The flowchart would looks like this:
 
-```mermaid
-%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'main-funnel'}} }%%
-gitGraph
-  commit id: "A"
-  commit id: "B"
-  branch "b-funnel"
-  checkout "b-funnel"
-  commit id: "B-1"
-  commit id: "B-2"
-  commit id: "B-3"
-  checkout "main-funnel"
-  merge "b-funnel"
-  commit id: "C"
-```
+<div className="w-full overflow-x-auto">
+  <div className="min-w-0 flex justify-center scale-[0.65] sm:scale-75 md:scale-85 lg:scale-100">
+    ```mermaid
+    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'main-funnel', 'rotateCommitLabel': false}} }%%
+    gitGraph
+      commit id: "A"
+      commit id: "B"
+      branch "b-funnel"
+      checkout "b-funnel"
+      commit id: "B-1"
+      commit id: "B-2"
+      commit id: "B-3"
+      checkout "main-funnel"
+      merge "b-funnel"
+      commit id: "C"
+    ```
+  </div>
+</div>
 
 `@use-funnel` supports sub-funnels. You simply need to specify a different `id` when using [`useFunnel()`](./use-funnel.mdx) in the components with in a particular <Keyword>step</Keyword>.
-
 
 <div className='h-8' />
 <Sandpack>
 
 ```tsx Example.tsx active
-import { useFunnel } from "@use-funnel/react-router-dom";
+import { useFunnel } from '@use-funnel/react-router-dom';
 
-import { BFunnel } from "./BFunnel";
+import { BFunnel } from './BFunnel';
 
 export function Example() {
   const funnel = useFunnel<{
-    A: { a?: string; b?: string; };
-    B: { a: string; b?: string; };
-    C: { a: string; b: string; };
+    A: { a?: string; b?: string };
+    B: { a: string; b?: string };
+    C: { a: string; b: string };
   }>({
-    id: "main-funnel",
+    id: 'main-funnel',
     initial: {
-      step: "A",
-      context: {}
-    }
+      step: 'A',
+      context: {},
+    },
   });
   return (
     <funnel.Render
@@ -53,7 +56,7 @@ export function Example() {
       B={({ context, history }) => (
         <div>
           <h1>B Step</h1>
-          <BFunnel a={context.a} onNext={b => history.push('C', { b })} />
+          <BFunnel a={context.a} onNext={(b) => history.push('C', { b })} />
         </div>
       )}
       C={({ context }) => (
@@ -64,12 +67,12 @@ export function Example() {
         </div>
       )}
     />
-  )
+  );
 }
 ```
 
 ```tsx BFunnel.tsx
-import { useFunnel } from "@use-funnel/react-router-dom";
+import { useFunnel } from '@use-funnel/react-router-dom';
 
 interface Props {
   a: string;
@@ -78,15 +81,15 @@ interface Props {
 
 export function BFunnel({ a, onNext }: Props) {
   const funnel = useFunnel<{
-    B1: { hello?: string; world?: string;};
-    B2: { hello: string; world?: string; };
-    B3: { hello: string; world: string; };
+    B1: { hello?: string; world?: string };
+    B2: { hello: string; world?: string };
+    B3: { hello: string; world: string };
   }>({
-    id: "b-funnel",
+    id: 'b-funnel',
     initial: {
-      step: "B1",
-      context: {}
-    }
+      step: 'B1',
+      context: {},
+    },
   });
   return (
     <funnel.Render
@@ -115,7 +118,7 @@ export function BFunnel({ a, onNext }: Props) {
         </div>
       )}
     />
-  )
+  );
 }
 ```
 

--- a/docs/src/pages/docs/sub-funnel.ko.mdx
+++ b/docs/src/pages/docs/sub-funnel.ko.mdx
@@ -5,7 +5,7 @@ import { Keyword, Sandpack } from '@/components'
 퍼널을 개발하다 보면 하나의 상태를 만들기 위해 여러 단계를 거쳐야 할 때가 있어요. 또는 일정 부분의 퍼널 단계를 다른 곳에서 재활용해야 할 때도 있어요. 이럴 때 퍼널을 서브 퍼널로 나누면 효율적이에요. 흐름도로 보면 다음과 같아요.
 
 <div className="w-full overflow-x-auto">
-  <div className="min-w-0 flex justify-center transform-gpu scale-75 sm:scale-90 md:scale-100 origin-center">
+  <div className="min-w-0 flex justify-center scale-[0.65] sm:scale-75 md:scale-85 lg:scale-100">
     ```mermaid
     %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'main-funnel', 'rotateCommitLabel': false}} }%%
     gitGraph

--- a/docs/src/pages/docs/sub-funnel.ko.mdx
+++ b/docs/src/pages/docs/sub-funnel.ko.mdx
@@ -4,20 +4,24 @@ import { Keyword, Sandpack } from '@/components'
 
 퍼널을 개발하다 보면 하나의 상태를 만들기 위해 여러 단계를 거쳐야 할 때가 있어요. 또는 일정 부분의 퍼널 단계를 다른 곳에서 재활용해야 할 때도 있어요. 이럴 때 퍼널을 서브 퍼널로 나누면 효율적이에요. 흐름도로 보면 다음과 같아요.
 
-```mermaid
-%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'main-funnel'}} }%%
-gitGraph
-  commit id: "A"
-  commit id: "B"
-  branch "b-funnel"
-  checkout "b-funnel"
-  commit id: "B-1"
-  commit id: "B-2"
-  commit id: "B-3"
-  checkout "main-funnel"
-  merge "b-funnel"
-  commit id: "C"
-```
+<div className="w-full overflow-x-auto">
+  <div className="min-w-0 flex justify-center transform-gpu scale-75 sm:scale-90 md:scale-100 origin-center">
+    ```mermaid
+    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'main-funnel', 'rotateCommitLabel': false}} }%%
+    gitGraph
+      commit id: "A"
+      commit id: "B"
+      branch "b-funnel"
+      checkout "b-funnel"
+      commit id: "B-1"
+      commit id: "B-2"
+      commit id: "B-3"
+      checkout "main-funnel"
+      merge "b-funnel"
+      commit id: "C"
+    ```
+  </div>
+</div>
 
 `@use-funnel`은 서브 퍼널을 지원해요. 간단하게 <Keyword>step</Keyword> 하위의 컴포넌트에서 [`useFunnel()`](./use-funnel.ko.mdx)을 사용할 때 다른 `id`를 지정하면 돼요.
 


### PR DESCRIPTION
# Modified HomePage for tablet, mobile screen
## Summary
This PR fixes the issue where items were breaking on screen sizes below md(768px).
## Changes Made
- **Updated** `HomePage.tsx` with responsive design support for small screens.
## What's changed
- Modified the layout to use flex-col instead of flex-row on screen widths below xl(1280px).
**Before `ko`(used iPad Air in Chrome Device)**
<img width="489" height="706" alt="스크린샷 2025-07-14 21 37 16" src="https://github.com/user-attachments/assets/a10577f1-4f11-45c8-a326-d4945a79120c" />
**After `ko`(used iPad Air in Chrome Device)**
<img width="490" height="703" alt="스크린샷 2025-07-14 21 38 36" src="https://github.com/user-attachments/assets/687e94cc-69b0-4d12-b376-69fe41da1d7c" />
**After `en`(used iPad Air in Chrome Device)**
<img width="488" height="702" alt="스크린샷 2025-07-14 21 41 42" src="https://github.com/user-attachments/assets/81cd9463-7989-46ef-b688-4f2141ee74f0" />
