### PR TITLE
feat(docs): Add App Router usage guide and client-only rendering example for @use-funnel/browser

### DIFF
--- a/.changeset/shaggy-insects-obey.md
+++ b/.changeset/shaggy-insects-obey.md
@@ -1,0 +1,5 @@
+---
+'@use-funnel/next': patch
+---
+
+fix wrong next/router import path

--- a/.changeset/shaggy-insects-obey.md
+++ b/.changeset/shaggy-insects-obey.md
@@ -1,5 +1,0 @@
----
-'@use-funnel/next': patch
----
-
-fix wrong next/router import path

--- a/docs/src/components/UseFunnelCodeBlock.tsx
+++ b/docs/src/components/UseFunnelCodeBlock.tsx
@@ -28,27 +28,34 @@ export const useFunnelPackages = [
   },
 ];
 
-interface UseFunnelCodeBlockProps {
-  renderSupplement?: ({ packageTitle }: { packageTitle: string }) => React.ReactNode;
-}
-
-export function UseFunnelCodeBlock({
-  children,
-  renderSupplement: RenderSupplement,
-}: React.PropsWithChildren<UseFunnelCodeBlockProps>) {
+export function UseFunnelCodeBlock({ children }: React.PropsWithChildren<unknown>) {
   return (
     <Tabs items={useFunnelPackages.map((p) => p.packageTitle)} storageKey="favorite-package">
       {useFunnelPackages.map((item) => (
         <Tabs.Tab key={item.packageTitle}>
           <UseFunnelImportReplace packageName={item.packageName}>{children}</UseFunnelImportReplace>
-          {RenderSupplement && <RenderSupplement packageTitle={item.packageTitle} />}
         </Tabs.Tab>
       ))}
     </Tabs>
   );
 }
 
-function UseFunnelImportReplace({
+interface UseFunnelCodeBlockTabsProps {
+  tabItems: typeof useFunnelPackages;
+}
+export function UseFunnelCodeBlockTabs({ tabItems, children }: React.PropsWithChildren<UseFunnelCodeBlockTabsProps>) {
+  return (
+    <>
+      {tabItems.map((item) => (
+        <Tabs.Tab key={item.packageTitle}>
+          <UseFunnelImportReplace packageName={item.packageName}>{children}</UseFunnelImportReplace>
+        </Tabs.Tab>
+      ))}
+    </>
+  );
+}
+
+export function UseFunnelImportReplace({
   children,
   packageName,
 }: React.PropsWithChildren<{

--- a/docs/src/pages/docs/get-started.en.mdx
+++ b/docs/src/pages/docs/get-started.en.mdx
@@ -1,5 +1,6 @@
-import { Steps, Callout } from 'nextra/components'
-import { UseFunnelCodeBlock, Keyword, useFunnelPackages } from '@/components'
+import { Steps, Callout } from 'nextra/components';
+import { UseFunnelCodeBlock, Keyword, useFunnelPackages, UseFunnelCodeBlockTabs } from '@/components';
+import { Tabs } from 'nextra/components';
 
 # Getting Started
 
@@ -35,12 +36,10 @@ First, specify the object type with the key as the step and the context object a
 
 Here, we set the initial step to "EmailInput" and an empty `context` object to be used in that step. `id` is a unique identifier to distinguish when there are multiple funnels in one component.
 
-<UseFunnelCodeBlock
-  renderSupplement={({ packageTitle }) => {
-    if (packageTitle === useFunnelPackages[0].packageTitle) {
-      return (
-        <Callout type="warning">
-          <strong>Note:</strong> Since <code>@use-funnel/browser</code> relies on the browser's history
+<Tabs items={useFunnelPackages.map((p) => p.packageTitle)} storageKey="favorite-package">
+<Tabs.Tab>
+{<Callout type="warning">
+  <strong>Note:</strong> Since <code>@use-funnel/browser</code> relies on the browser's history
           state, it cannot be hydrated on the server. This means it must run exclusively on the client. To make sure 
           it works correctly, you can either render it conditionally after mounting in a parent component or use a{' '}
           <code>ssr: false</code> configuration with{' '}
@@ -52,14 +51,27 @@ Here, we set the initial step to "EmailInput" and an empty `context` object to b
             next/dynamic
           </a>{' '}
           to create the funnel component.
-        </Callout>
-      );
-    }
-  }}
->
+</Callout>}
+
+```tsx {6-10}
+import { useState, useEffect } from 'react';
+
+export default function Page() {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) return null;
+
+  return <MyFunnelApp />;
+}
+```
+
 ```tsx {5-15}
-import { useFunnel } from "@use-funnel/next";
-import type { EmailInput, PasswordInput, OtherInfoInput } "./context";
+import { useFunnel } from '@use-funnel/browser';
+import type { EmailInput, PasswordInput, OtherInfoInput } from './context';
 
 function MyFunnelApp() {
   const funnel = useFunnel<{
@@ -70,13 +82,38 @@ function MyFunnelApp() {
     id: "my-funnel-app",
     initial: {
       step: "EmailInput",
-      context: {}
-    }
+      context: {},
+    },
   });
   // ...
 }
 ```
-</UseFunnelCodeBlock>
+
+</Tabs.Tab>
+<UseFunnelCodeBlockTabs tabItems={useFunnelPackages.filter(item => item.packageTitle !== useFunnelPackages[0].packageTitle)}>
+
+```tsx {5-15}
+import { useFunnel } from '@use-funnel/next';
+import type { EmailInput, PasswordInput, OtherInfoInput } from './context';
+
+function MyFunnelApp() {
+  const funnel = useFunnel<{
+    EmailInput: EmailInput;
+    PasswordInput: PasswordInput;
+    OtherInfoInput: OtherInfoInput;
+  }>({
+    id: 'my-funnel-app',
+    initial: {
+      step: "EmailInput",
+      context: {},
+    },
+  });
+  // ...
+}
+```
+
+</UseFunnelCodeBlockTabs>
+</Tabs>
 
 For other ways to define the state of each step, see the [state definition guide](/docs/context-guide).
 

--- a/docs/src/pages/docs/get-started.ko.mdx
+++ b/docs/src/pages/docs/get-started.ko.mdx
@@ -1,5 +1,6 @@
 import { Steps, Callout } from 'nextra/components'
-import { UseFunnelCodeBlock, Keyword, useFunnelPackages } from '@/components'
+import { UseFunnelCodeBlock, Keyword, useFunnelPackages, UseFunnelCodeBlockTabs } from '@/components'
+import { Tabs } from 'nextra/components'
 
 # 시작하기
 
@@ -35,30 +36,40 @@ type 그외정보입력 = { email: string; password: string; other?: unknown }
 
 여기서는 초기 단계인 "이메일입력"과 해당 단계에서 사용할 빈 `context` 객체를 설정했어요. `id`는 [한 컴포넌트에 여러 퍼널](/docs/sub-funnel)이 있을 때 구분하기 위한 고유 식별자에요.
 
-<UseFunnelCodeBlock
-  renderSupplement={({ packageTitle }) => {
-    if (packageTitle === useFunnelPackages[0].packageTitle) {
-      return (
-        <Callout type="warning">
-            <strong>주의할 점:</strong> <code>@use-funnel/browser</code>의 경우 브라우저의 히스토리 상태를 기반으로
-            동작하기 때문에 서버에서 <code>Hydration</code>을 기대하기 어려워요. 그래서 오로지 클라이언트에서만 실행될 수 있도록 상위
-            컴포넌트에서 <code>mount</code>후에 렌더링 하게하거나,{' '}
-            <a
-              href="https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#nextdynamic"
-              target="_blank"
-              rel="noreferrer"
-            >
-              next/dynamic
-            </a>
-            의 컴포넌트를 통해 <code>ssr: false</code> 형태로 퍼널 컴포넌트를 만들어야해요.
-        </Callout>
-      );
-    }
-  }}
->
+<Tabs items={useFunnelPackages.map((p) => p.packageTitle)} storageKey="favorite-package">
+<Tabs.Tab>
+{<Callout type="warning">
+  <strong>주의할 점:</strong> <code>@use-funnel/browser</code>의 경우 브라우저의 히스토리 상태를 기반으로 동작하기
+  때문에 서버에서 <code>Hydration</code>을 기대하기 어려워요. 그래서 오로지 클라이언트에서만 실행될 수 있도록 상위
+  컴포넌트에서 <code>mount</code>후에 렌더링 하게하거나,{' '}
+  <a
+    href="https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#nextdynamic"
+    target="_blank"
+    rel="noreferrer"
+  >
+    next/dynamic
+  </a>
+  의 컴포넌트를 통해 <code>ssr: false</code> 형태로 퍼널 컴포넌트를 만들어야해요.
+</Callout>}
+
+```tsx {6-10}
+import { useState, useEffect } from 'react';
+
+export default function Page() {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) return null;
+
+  return <MyFunnelApp />;
+}
+```
 ```tsx {5-15}
-import { useFunnel } from "@use-funnel/next";
-import type { 이메일입력, 비밀번호입력, 그외정보입력 } "./context";
+import { useFunnel } from '@use-funnel/browser';
+import type { 이메일입력, 비밀번호입력, 그외정보입력 } from "./context";
 
 function MyFunnelApp() {
   const funnel = useFunnel<{
@@ -75,7 +86,32 @@ function MyFunnelApp() {
   // ...
 }
 ```
-</UseFunnelCodeBlock>
+
+
+</Tabs.Tab>
+<UseFunnelCodeBlockTabs tabItems={useFunnelPackages.filter(item => item.packageTitle !== useFunnelPackages[0].packageTitle)}>
+
+```tsx {5-15}
+import { useFunnel } from "@use-funnel/next";
+import type { 이메일입력, 비밀번호입력, 그외정보입력 } from "./context";
+
+function MyFunnelApp() {
+  const funnel = useFunnel<{
+    이메일입력: 이메일입력;
+    비밀번호입력: 비밀번호입력;
+    그외정보입력: 그외정보입력;
+  }>({
+    id: "my-funnel-app",
+    initial: {
+      step: "이메일입력",
+      context: {}
+    }
+  });
+  // ...
+}
+```
+</UseFunnelCodeBlockTabs>
+</Tabs>
 
 이 방법 이외의 <Keyword>step</Keyword> 별 상태 정의는 [상태 정의 가이드](/docs/context-guide)를 참고하세요.
     

--- a/docs/src/pages/docs/install.en.mdx
+++ b/docs/src/pages/docs/install.en.mdx
@@ -5,7 +5,8 @@
 - [react-router](https://reactrouter.com/home)
   - For the [react-router-dom](https://reactrouter.com/upgrading/v6), use `@use-funnel/react-router-dom` package.
 - [next.js page router](https://nextjs.org/docs/pages)
-  - For the [next.js app router](https://nextjs.org/docs/app/building-your-application), use `@use-funnel/browser` package with `ssr: false` option.
+- [next.js app router](https://nextjs.org/docs/app/building-your-application): use the `@use-funnel/browser` package.  
+  A dedicated adapter is not yet available, so refer to the [official guide](https://use-funnel.slash.page/docs/get-started#configuring-the-initial-step) for implementation details.
 - [@react-navigation/native](https://reactnavigation.org/docs/getting-started)
 - [browser history](https://developer.mozilla.org/en-US/docs/Web/API/History)
 

--- a/docs/src/pages/docs/install.ko.mdx
+++ b/docs/src/pages/docs/install.ko.mdx
@@ -5,7 +5,7 @@
 - [react-router](https://reactrouter.com/home)
   - [react-router-dom](https://reactrouter.com/upgrading/v6)의 경우 `@use-funnel/react-router-dom` 패키지를 사용해주세요.
 - [next.js page router](https://nextjs.org/docs/pages)
-  - [next.js app router](https://nextjs.org/docs/app/building-your-application) 는 `@use-funnel/browser` 패키지를 `ssr: false` 옵션과 함께 사용해주세요.
+- [next.js app router](https://nextjs.org/docs/app/building-your-application)의 경우 `@use-funnel/browser` 패키지를 사용해주세요. 현재 전용 어댑터를 지원하지 않으므로, 자세한 구현은 [공식 가이드](https://use-funnel.slash.page/docs/get-started#configuring-the-initial-step)를 참고해주세요.
 - [@react-navigation/native](https://reactnavigation.org/)
 - [browser history](https://developer.mozilla.org/en-US/docs/Web/API/History)
 
@@ -16,7 +16,7 @@
 
 ## 설치 방법
 
-사용할 라우터를 선택하고, 다음 명령어를 사용해서 패키지를 설치해주세요.
+사용할 라우터에 맞는 패키지를 선택해 설치해주세요.
 
 ```shell npm2yarn
 npm install @use-funnel/react-router --save


### PR DESCRIPTION
Add App Router usage guide and client-only rendering example for @use-funnel/browser

# Changes
## Installation
|KO|EN|
|--|--|
|<img width="683" height="298" alt="스크린샷 2025-08-31 오후 11 46 07" src="https://github.com/user-attachments/assets/2b708f32-a733-4b27-b738-663bc89b6465" />|<img width="607" height="311" alt="스크린샷 2025-08-31 오후 11 45 57" src="https://github.com/user-attachments/assets/39788800-91f2-419f-bab3-d08bca236e48" />|
## Getting Started
|KO|EN|
|--|--|
|<img width="675" height="787" alt="스크린샷 2025-08-31 오후 11 46 29" src="https://github.com/user-attachments/assets/aedefffd-5c6d-4130-874f-d4ec92a71b2f" />|<img width="660" height="801" alt="스크린샷 2025-08-31 오후 11 45 45" src="https://github.com/user-attachments/assets/389c5b65-faf6-44f7-9000-cb4784fff7f7" />|



